### PR TITLE
Amqp rpc server accepts custom error handler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
 - '7.0'
 - '7.1'
+- '7.2'
 - nightly
 matrix:
   allow_failures:
@@ -10,7 +11,7 @@ matrix:
   fast_finish: true
 env:
   global:
-  - ARCHER_PUBLISH_VERSION=5.6
+  - ARCHER_PUBLISH_VERSION=7.1
   - secure: FIF+gp2tG2b1exzUIhYOtyNJFPl6yCa4PQQf9DQ8QNZmwm9D9lZzupB2Eha1KfTIZFnL1/Xy/Yv18QhnOeAKExEf/d68UBG6Fvu1Mq6Ov3zh59J1LdW7gsep8+XSlbf/7kOiTHjDztSgFBN7wQ1KT08ku04sX8XWm3NAK0/mVM0=
 install:
 - ./.travis.install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: php
 php:
-- '5.5'
-- '5.6'
 - '7.0'
-- hhvm
-- hhvm-nightly
+- '7.1'
+- nightly
 matrix:
   allow_failures:
-  - php: hhvm
-  - php: hhvm-nightly
+  - php: '7.2'
+  - php: nightly
   fast_finish: true
 env:
   global:

--- a/src/Amqp/JobQueue/AmqpWorker.php
+++ b/src/Amqp/JobQueue/AmqpWorker.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use ReflectionClass;
+use Throwable;
 
 class AmqpWorker implements WorkerInterface
 {
@@ -29,6 +30,7 @@ class AmqpWorker implements WorkerInterface
     /**
      * @param LoggerInterface             $logger
      * @param AMQPChannel                 $channel
+     * @param callable|null               $errorHandler
      * @param DeclarationManager|null     $declarationManager
      * @param SerializationInterface|null $serialization
      * @param ChannelDispatcher           $channelDispatcher
@@ -36,11 +38,13 @@ class AmqpWorker implements WorkerInterface
     public function __construct(
         LoggerInterface $logger,
         AMQPChannel $channel,
+        callable $errorHandler = null,
         DeclarationManager $declarationManager = null,
         JobSerializationInterface $serialization = null,
         ChannelDispatcher $channelDispatcher = null
     ) {
         $this->channel = $channel;
+        $this->errorHandler       = $errorHandler;
         $this->declarationManager = $declarationManager ?: new DeclarationManager($channel);
         $this->serialization = $serialization ?: new JobSerialization(new JsonSerialization());
         $this->channelDispatcher = $channelDispatcher ?: new ChannelDispatcher();
@@ -130,6 +134,11 @@ class AmqpWorker implements WorkerInterface
             }
         }
 
+        if ($this->uncaughtThrowable !== null) {
+            $this->logger->critical('rjobqueue.worker shutdown due to uncaught exception');
+            throw $this->uncaughtThrowable;
+        }
+
         $this->logger->info('jobqueue.worker shutdown gracefully');
     }
 
@@ -195,7 +204,21 @@ class AmqpWorker implements WorkerInterface
         } catch (ErrorException $e) {
             $logLevel = LogLevel::ERROR;
             $logMessage = $this->handleFailure($message, $e, $logContext);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
+            if (null !== $this->errorHandler) {
+                try {
+                    $fn = $this->errorHandler;
+                    $fn($e);
+                } catch (Throwable $e) {
+                    $this->isStopping = true;
+                    $this->uncaughtThrowable = $e;
+                }
+            }
+
+            if ($e instanceof Error) {
+                $e = new Exception('Internal server error.', $e->getCode());
+            }
+
             $logLevel = LogLevel::ERROR;
             $logContext['exception'] = $e;
             $logMessage = $this->handleFailure(
@@ -203,11 +226,6 @@ class AmqpWorker implements WorkerInterface
                 new Exception('Internal server error.', $e->getCode()),
                 $logContext
             );
-        } catch (Error $e) {
-            $logLevel = LogLevel::ERROR;
-            $e = new Exception('Internal server error.', $e->getCode());
-            $logContext['exception'] = $e;
-            $logMessage = $this->handleFailure($message, $e, $logContext);
         }
 
         $this->logger->debug(
@@ -279,10 +297,12 @@ class AmqpWorker implements WorkerInterface
     }
 
     private $channel;
+    private $errorHandler;
     private $declarationManager;
     private $serialization;
     private $channelDispatcher;
     private $isStopping;
+    private $uncaughtThrowable;
     private $handlers;
     private $consumerTags;
 }

--- a/src/Amqp/Rpc/AmqpRpcServer.php
+++ b/src/Amqp/Rpc/AmqpRpcServer.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use ReflectionClass;
+use Throwable;
 
 class AmqpRpcServer implements RpcServerInterface
 {
@@ -31,7 +32,7 @@ class AmqpRpcServer implements RpcServerInterface
     /**
      * @param LoggerInterface                    $logger
      * @param AMQPChannel                        $channel
-     * @param callable|nul                       $errorHandler
+     * @param callable|null                      $errorHandler
      * @param DeclarationManager|null            $declarationManager
      * @param MessageSerializationInterface|null $serialization
      * @param InvokerInterface|null              $invoker
@@ -144,9 +145,9 @@ class AmqpRpcServer implements RpcServerInterface
             }
         }
 
-        if ($this->uncaughtException !== null) {
+        if ($this->uncaughtThrowable !== null) {
             $this->logger->critical('rpc.server shutdown due to uncaught exception');
-            throw $this->uncaughtException;
+            throw $this->uncaughtThrowable;
         }
 
         $this->logger->info('rpc.server shutdown gracefully');
@@ -282,13 +283,13 @@ class AmqpRpcServer implements RpcServerInterface
                 try {
                     $fn = $this->errorHandler;
                     $fn($e);
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     $this->isStopping = true;
-                    $this->uncaughtException = $e;
+                    $this->uncaughtThrowable = $e;
                 }
             } else {
                 $this->isStopping = true;
-                $this->uncaughtException = $e;
+                $this->uncaughtThrowable = $e;
             }
         }
 
@@ -343,13 +344,13 @@ class AmqpRpcServer implements RpcServerInterface
     }
 
     private $channel;
+    private $errorHandler;
     private $declarationManager;
     private $serialization;
     private $invoker;
     private $channelDispatcher;
-    private $errorHandler;
     private $isStopping;
-    private $uncaughtException;
+    private $uncaughtThrowable;
     private $procedures;
     private $consumerTags;
 }

--- a/test/suite/Amqp/JobQueue/AmqpWorkerTest.php
+++ b/test/suite/Amqp/JobQueue/AmqpWorkerTest.php
@@ -76,6 +76,7 @@ class AmqpWorkerTest extends PHPUnit_Framework_TestCase
             AmqpWorker::class,
             $this->logger,
             $this->channel,
+            null,
             $this->declarationManager,
             null,
             $this->channelDispatcher

--- a/test/suite/Amqp/JobQueue/AmqpWorkerTest.php
+++ b/test/suite/Amqp/JobQueue/AmqpWorkerTest.php
@@ -3,6 +3,7 @@
 namespace Icecave\Overpass\Amqp\JobQueue;
 
 use Eloquent\Asplode\Error\ErrorException;
+use Error;
 use Exception;
 use Icecave\Overpass\Amqp\ChannelDispatcher;
 use Icecave\Overpass\JobQueue\Exception\DiscardException;
@@ -14,6 +15,7 @@ use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Throwable;
 
 class AmqpWorkerTest extends PHPUnit_Framework_TestCase
 {
@@ -545,12 +547,10 @@ class AmqpWorkerTest extends PHPUnit_Framework_TestCase
      */
     public function testReceiveRequestWithError()
     {
-        $exception = new Exception('Internal server error.', 0);
+        $exception = new Error('A bad server error has happened.', 0);
         $this->worker->register(
             'job-type',
-            function (int $foo) { // will cause TypeError in php7 and asplode ErrorException in php5 when we invoke with an object
-                return $foo;
-            }
+            function ($foo) use ($exception) { throw $exception; }
         );
 
         $this->worker->run();
@@ -595,12 +595,146 @@ class AmqpWorkerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
                 'code' => 0,
+                'reason' => '"Internal server error."',
                 'type' => 'job-type',
                 'payload' => '[1,{"a":2,"b":3}]',
-                'reason' => '"Internal server error."',
                 'exception' => $exception,
             ],
             $context
         );
     }
+
+    public function testReceiveRequestWithCustomErrorHandlerThatCompletes()
+    {
+        $exception = new Error('The procedure imploded spectacularly!');
+        $worker = Phake::partialMock(
+            AmqpWorker::class,
+            $this->logger,
+            $this->channel,
+            function (Throwable $e) { /* no exception being thrown. */ },
+            $this->declarationManager,
+            null,
+            $this->channelDispatcher
+        );
+        $worker->register(
+            'job-type',
+            function() use ($exception) { throw $exception; }
+        );
+
+        $worker->run();
+
+        $handler = null;
+
+        Phake::verify($this->channel)->basic_consume(
+            '<job-queue-job-type>',
+            '',    // consumer tag
+            false, // no local
+            false, // no ack
+            false, // exclusive
+            false, // no wait
+            Phake::capture($handler)
+        );
+
+        $jobRequest = new AMQPMessage('["job-type",[1,{"a":2,"b":3}]]', []);
+        $jobRequest->delivery_info['delivery_tag'] = '<delivery-tag>';
+        $jobRequest->delivery_info['redelivered'] = false;
+
+        $handler($jobRequest);
+
+        $context = null;
+
+        Phake::verify($this->logger)->debug(
+            'jobqueue.worker started job {type}({payload})',
+            Phake::capture($context)
+        );
+
+        Phake::verify($this->logger)->debug(
+            'jobqueue.worker finished job {type}({payload})',
+            Phake::capture($context)
+        );
+
+        Phake::verify($this->logger)->log(
+            LogLevel::ERROR,
+            'jobqueue.worker requeuing failed job {type} -> {code} {reason}',
+            Phake::capture($context)
+        );
+
+        $this->assertEquals(
+            [
+                'code' => 0,
+                'reason' => '"Internal server error."',
+                'type' => 'job-type',
+                'payload' => '[1,{"a":2,"b":3}]',
+                'exception' => $exception,
+            ],
+            $context
+        );
+    }
+
+    public function testReceiveRequestWithCustomErrorHandlerThatThrows()
+    {
+        Phake::when($this->channelDispatcher)
+            ->wait($this->channel)
+            ->thenGetReturnByLambda(
+                function () {
+                    $handler = null;
+
+                    Phake::verify($this->channel)->basic_consume(
+                        '<job-queue-job-type>',
+                        '',    // consumer tag
+                        false, // no local
+                        false, // no ack
+                        false, // exclusive
+                        false, // no wait
+                        Phake::capture($handler)
+                    );
+
+                    $jobRequest = new AMQPMessage(
+                        '["job-type",[1,2,3]]',
+                        [
+                            'reply_to' => '<response-queue>',
+                        ]
+                    );
+                    $jobRequest->delivery_info['delivery_tag'] = '<delivery-tag>';
+                    $jobRequest->delivery_info['redelivered'] = false;
+
+                    $handler($jobRequest);
+                }
+            )
+            ->thenReturn(null);
+
+        $errorException = new Error('Error handler throws an error exception.');
+        $exceptioned = false;
+
+        $worker = Phake::partialMock(
+            AmqpWorker::class,
+            $this->logger,
+            $this->channel,
+            function (Throwable $e) use ($errorException) { throw $errorException; },
+            $this->declarationManager,
+            null,
+            $this->channelDispatcher
+        );
+        $worker->register(
+            'job-type',
+            function() {
+                throw new Error('The procedure imploded spectacularly!');
+            }
+        );
+
+        try {
+            $worker->run();
+        } catch (Throwable $e) {
+            Phake::verify($this->logger)->critical('jobqueue.worker shutdown due to uncaught exception');
+            Phake::verify($this->channel)->basic_cancel('<consumer-tag-1>');
+
+            $this->assertSame($errorException->getMessage(), $e->getMessage());
+
+            $exceptioned = true;
+        }
+
+        $this->assertTrue($exceptioned);
+    }
+
+
 }

--- a/test/suite/Amqp/Rpc/AmqpRpcServerTest.php
+++ b/test/suite/Amqp/Rpc/AmqpRpcServerTest.php
@@ -516,51 +516,10 @@ class AmqpRpcServerTest extends PHPUnit_Framework_TestCase
 
         $responseMessage = null;
 
-        $expectedRequest  = Request::create('procedure-name', [1, 2, 3]);
-        $expectedResponse = Response::createFromValue('<procedure-1: 1, 2, 3>');
-
-        Phake::inOrder(
-            Phake::verify($this->channel)->basic_ack('<delivery-tag>'),
-            Phake::verify($this->invoker)->invoke($expectedRequest, $this->procedure1),
-            Phake::verify($this->channel)->basic_publish(
-                Phake::capture($responseMessage),
-                '', // default direct exchange
-                '<response-queue>'
-            )
-        );
-
-        $context = null;
-
-        Phake::verify($this->logger)->debug(
-            'rpc.server {queue} #{id} REQUEST {procedure}({arguments})',
-            Phake::capture($context)
-        );
-
-        Phake::verify($this->logger)->debug(
-            'rpc.server {queue} #{id} RESPONSE {procedure}({arguments}) -> {code} {time} {value}',
-            Phake::capture($context)
-        );
-
-        Phake::verify($this->logger)->log(
-            LogLevel::ERROR,
-            'rpc.server {queue} #{id} {code} {procedure} {time}',
-            Phake::capture($context)
-        );
-
-        $this->assertEquals(
-            [
-                'id'        => 456,
-                'queue'     => '<response-queue>',
-                'procedure' => 'procedure-name',
-                'arguments' => '1, 2, 3',
-                'code'      => ResponseCode::EXCEPTION(),
-                'value'     => '"Internal server error."',
-                'time'      => '1.230000 ms',
-                'exception' => new Exception(
-                    'The procedure imploded spectacularly!'
-                )
-            ],
-            $context
+        Phake::verify($this->channel)->basic_publish(
+            Phake::capture($responseMessage),
+            '', // default direct exchange
+            '<response-queue>'
         );
 
         $this->assertEquals(


### PR DESCRIPTION
Error handler can deal with certain exception (and re-throw others) and then have the rpc continue operation normally afterwards.

Fixes #25.